### PR TITLE
docs: コミットメッセージにリリースバージョンの対応を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ npx husky install
 ### Commit message
 
 コミットメッセージは[Angularのコミットメッセージフォーマット](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)に従ってください。
-規約に従うことで、機械的な解析が可能になリリースが自動になります。詳しくは[リリース](#リリース)参照
+
+それによりリリースを自動化しています。詳しくは[リリース](#リリース)参照
 
 よく使うものを掲載します。scopeは不要です。
 
@@ -90,16 +91,16 @@ npx husky install
 fix: 日本語の副詞「と」のルールを修正
 ```
 
-| 種別 | 内容 |
-| -- | -- |
-| BREAKING CHANGE | 互換性のない破壊的変更 |
-| feat | 新しい機能 |
-| fix | バグ修正 |
-| perf | コードのパフォーマンス修正 |
-| refactor| バグ修正や機能追加のないリファクタリング |
-| test | テストパターンの追加や既存テストの修正 |
-| docs | ドキュメントの変更 |
-| chore | ビルドプロセスの改善など、上記に該当しないもの |
+| 種別 | 内容 | マージリリース| バージョン |
+| -- | -- | -- | -- |
+| feat | 新しい機能 | 〇 | Miner Release |
+| fix | バグ修正&軽微な修正 | 〇 | Patch Release |
+| perf | コードのパフォーマンス修正 | 〇 | Major Release |
+| BREAKING CHANGE | 互換性のない破壊的変更 | 〇 | Major Release |
+| refactor| バグ修正や機能追加のないリファクタリング | | |
+| test | テストパターンの追加や既存テストの修正 | | |
+| docs | ドキュメントの変更 | | |
+| chore | ビルドプロセスの改善など、上記に該当しないもの | | |
 
 ### Example execute
 


### PR DESCRIPTION
公式を参考に説明を追加
https://semantic-release.gitbook.io/semantic-release/#commit-message-format